### PR TITLE
added some comments, renamed some stuff, changed sweeps 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/Tritium-VLK/brownie@master
+git+https://github.com/BalancerMaxis/bal_addresses@0.6.0
+

--- a/scripts/configure.py
+++ b/scripts/configure.py
@@ -203,12 +203,12 @@ def register_upkeep(upkeep_contract,
     return json.dumps(payload)
 
 
-def set_recipient_list(streamer_addresses, amounts_per_period, max_periods, injector_address, safe_address, token_address, chain_id=chain.id):
+def set_recipient_list(gauge_addresses, amounts_per_period, max_periods, injector_address, safe_address, token_address, chain_id=chain.id):
     payload = json.loads(CONF_WATCHLIST_TEMPLATE)
     payload["chainId"] = chain_id
     payload["meta"]["createdFromSafeAddress"] = safe_address
     payload["transactions"][0]["to"] = injector_address
-    payload["transactions"][0]["contractInputsValues"]["gaugeAddresses"] = streamer_addresses
+    payload["transactions"][0]["contractInputsValues"]["gaugeAddresses"] = gauge_addresses
     payload["transactions"][0]["contractInputsValues"]["amountsPerPeriod"] = amounts_per_period
     payload["transactions"][0]["contractInputsValues"]["maxPeriods"] = max_periods
     ### Send coins

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -2,7 +2,7 @@ from brownie import (
     interface,
     accounts,
     chain,
-    periodicRewardsInjector,
+    ChildChainGaugeInjector,
 )
 
 
@@ -24,9 +24,9 @@ LINK_BY_CHAIN = {
 }
 
 
-injector = periodicRewardsInjector.deploy(
+injector = ChildChainGaugeInjector.deploy(
     REGISTRY_BY_CHAIN[chain.id],
-    60 * 60 * 7,  # minWaitPeriodSeconds is 1 week
+    60 * 60 * 6,  # minWaitPeriodSeconds is 6 days
     TOKEN_ADDRESS,
     {"from": account},
     publish_source=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import time
 from brownie import (
     interface,
     accounts,
-    periodicRewardsInjector,
+    ChildChainGaugeInjector,
     Contract
 
 )
@@ -20,7 +20,6 @@ ARBI_LDO_WHALE = "0x8565faab405b06936014c8b6bd5ab60376cc051b"
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 ARBI_LDO_ADDRESS = "0xC3C7d422809852031b44ab29EEC9F1EfF2A58756"
 WEEKLY_INCENTIVE = 200*10**18
-STREAMER_STUCK = 6003155 ## Something that seems stuck in the streamer LDO
 LM_MULTISIG ="0xc38c5f97B34E175FFd35407fc91a937300E33860"
 ## weth, usdt, usdc
 TOKEN_LIST = [

--- a/tests/test_periodicEmissionsInjector.py
+++ b/tests/test_periodicEmissionsInjector.py
@@ -201,11 +201,11 @@ def test_sweep(admin, injector, token, deployer):
     assert token.balanceOf(admin) > 0
     token.transfer(injector, token.balanceOf(admin), {"from": admin})
     assert token.balanceOf(admin) == 0
-    injector.sweep(token, admin, {"from": admin})
+    injector.sweep(token, {"from": admin})
     assert token.balanceOf(admin) >= admin_balance
     assert token.balanceOf(admin) + token.balanceOf(injector) == system_balance
     with brownie.reverts("Only callable by owner"):
-        injector.sweep(deployer, injector, {"from": deployer})
+        injector.sweep(token, {"from": deployer})
 
 def test_sweep_multitoken(admin, injector, token, deployer, token_list):
     for test_token in token_list:
@@ -215,12 +215,11 @@ def test_sweep_multitoken(admin, injector, token, deployer, token_list):
         assert tok.balanceOf(admin) > 0
         tok.transfer(injector, tok.balanceOf(admin), {"from": admin})
         assert tok.balanceOf(admin) == 0
-        injector.sweep(tok, admin, {"from": admin})
+        injector.sweep(tok, {"from": admin})
         assert tok.balanceOf(admin) >= admin_balance
         assert tok.balanceOf(admin) + tok.balanceOf(injector) == system_balance
-
-    with brownie.reverts("Only callable by owner"):
-        injector.sweep(deployer, injector, {"from": deployer})
+        with brownie.reverts("Only callable by owner"):
+            injector.sweep(token, {"from": deployer})
 
 def test_setDistributorToOwner(admin, injector, gauge, token, deployer, token_list):
     assert(gauge.reward_data(token.address)[0] == injector.address)


### PR DESCRIPTION
to only allow transfer back to owner as per advice from integrations on the bb-e-usd arb contract.

Have not tested deploy/config guides with the new gauge type yet, but we can do so and update the docs on the first deploy/activation.

